### PR TITLE
update virtual and physical dynamic groups to account for Windows Vir…

### DIFF
--- a/Source/Resources/Content/MSGraph/Groups/Baseline - Corporate Devices - Physical.json
+++ b/Source/Resources/Content/MSGraph/Groups/Baseline - Corporate Devices - Physical.json
@@ -6,7 +6,7 @@
   ],
   "mailEnabled": false,
   "mailNickname": "Baseline-CorporateDevices-Physical",
-  "membershipRule": "((device.devicePhysicalIDs -any (_ -contains \"[ZTDId]\")) -or (device.deviceOwnership -eq \"Company\")) and (device.deviceManufacturer -notstartswith \"VMWare\") and (device.deviceManufacturer -notstartswith \"Parallels\") and (device.deviceModel -ne \"Virtual Machine\")",
+  "membershipRule": "((device.devicePhysicalIDs -any (_ -contains \"[ZTDId]\")) -or (device.deviceOwnership -eq \"Company\")) and (device.deviceManufacturer -notstartswith \"VMWare\") and (device.deviceManufacturer -notstartswith \"Parallels\") and (device.deviceModel -ne \"Virtual Machine\") and (device.deviceModel -notContains \"Cloud PC\")",
   "resourceBehaviorOptions": [],
   "resourceProvisioningOptions": [],
   "securityEnabled": true

--- a/Source/Resources/Content/MSGraph/Groups/Baseline - Corporate Devices - Virtual.json
+++ b/Source/Resources/Content/MSGraph/Groups/Baseline - Corporate Devices - Virtual.json
@@ -6,7 +6,7 @@
   ],
   "mailEnabled": false,
   "mailNickname": "Baseline-CorporateDevices-Virtual",
-  "membershipRule": "((device.devicePhysicalIDs -any (_ -contains \"[ZTDId]\")) -or (device.deviceOwnership -eq \"Company\")) and ((device.deviceManufacturer -startswith \"VMWare\") or (device.deviceManufacturer -startswith \"Parallels\") or (device.deviceModel -eq \"Virtual Machine\"))",
+  "membershipRule": "((device.devicePhysicalIDs -any (_ -contains \"[ZTDId]\")) -or (device.deviceOwnership -eq \"Company\")) and ((device.deviceManufacturer -startswith \"VMWare\") or (device.deviceManufacturer -startswith \"Parallels\") or (device.deviceModel -eq \"Virtual Machine\") or (device.deviceModel -contains \"Cloud PC\"))",
   "resourceBehaviorOptions": [],
   "resourceProvisioningOptions": [],
   "securityEnabled": true


### PR DESCRIPTION
As reported, virtual and physical groups do not currently include Microsoft Cloud PCs. Should confirm that these work before merge.

For reference, found updated rules here: https://learn.microsoft.com/en-us/windows-365/enterprise/create-dynamic-device-group-all-cloudpcs#create-a-dynamic-device-group-for-all-cloud-pcs