### PR TITLE
Fix - 'Add-LocalGroupMember' is not recognized

### DIFF
--- a/Source/Resources/Content/MSGraph/DeviceManagement/DeviceManagementScripts/Baseline - Security - Add-AuthenticatedUsersToRemoteDesktopUsers.json
+++ b/Source/Resources/Content/MSGraph/DeviceManagement/DeviceManagementScripts/Baseline - Security - Add-AuthenticatedUsersToRemoteDesktopUsers.json
@@ -10,6 +10,6 @@
   ],
   "enforceSignatureCheck": false,
   "fileName": "Baseline - Security - Add-AuthenticatedUsersToRemoteDesktopUsers.ps1",
-  "runAs32Bit": true,
+  "runAs32Bit": false,
   "runAsAccount": "system"
 }


### PR DESCRIPTION
Use 64 bit Powershell host to run the script correctly

Noticed the script not running correctly which I changed, this fixes it.

Error message form AgentExecutor.log below

```
error from script =Add-LocalGroupMember : The term 'Add-LocalGroupMember' is not recognized as the name of a cmdlet, function, script file
, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and t
ry again.
At C:\Program Files (x86)\Microsoft Intune Management Extension\Policies\Scripts\8235e421-95a8-47c2-a83a-b8997a83079d_f
d9d41a6-e2b8-4561-af8b-5f2c225655ad.ps1:1 char:1
+ Add-LocalGroupMember -SID "S-1-5-32-555" -Member 'S-1-5-11'
+ ~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Add-LocalGroupMember:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
 
```

